### PR TITLE
feat(service-auto-start): add auto-start support for rootless devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Shizuku
 
+## Disclaimer
+
+THIS IS A **FORK** OF SHIZUKU. IF YOU'RE LOOKING FOR SHIZUKU FROM RIKKA, THIS IS NOT THE PLACE.
+VISIT THE OFFICIAL REPO [**_HERE_**](https://github.com/RikkaApps/Shizuku)
+
+### Usage of auto-start
+
+- Follow the instructions for setting up Shizuku through Wireless ADB by pairing the app
+  - From the `Settings`, enable `Start on boot (wireless ADB)`
+    - `WRITE_SECURE_SETTINGS` permission needs to be granted prior to enabling this setting and this can be enabled either by `rish` or by connecting the device to the machine
+    - Run the following command:
+      ```bash
+      adb shell pm grant moe.shizuku.privileged.api android.permission.WRITE_SECURE_SETTINGS
+      ```
+
+> [!WARNING]
+> `WRITE_SECURE_SETTINGS` is a very sensitive permission and enable it only if you know what you're doing.
+> The developer of this fork is not responsible for whatever may happen later on.
+
+> [!NOTE]
+> Auto restart service is untested
+
 ## Background
 
 When developing apps that requires root, the most common method is to run some commands in the su shell. For example, there is an app that uses the `pm enable/disable` command to enable/disable components.

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -6,11 +6,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="moe.shizuku.manager.permission.MANAGER" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission
-        android:name="android.permission.ACCESS_WIFI_STATE"
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"
         tools:ignore="LeanbackUsesWifi" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission
@@ -142,8 +140,7 @@
         <service
             android:name=".starter.SelfStarterService"
             android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="connectedDevice" />
+            android:exported="false" />
 
         <receiver
             android:name=".receiver.BootCompleteReceiver"

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -4,9 +4,18 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="moe.shizuku.manager.permission.MANAGER" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission
+        android:name="android.permission.ACCESS_WIFI_STATE"
+        tools:ignore="LeanbackUsesWifi" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission
+        android:name="android.permission.WRITE_SECURE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
     <uses-permission
         android:name="moe.shizuku.manager.permission.API_V23"
         tools:node="remove" />
@@ -126,6 +135,12 @@
 
         <service
             android:name=".adb.AdbPairingService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
+        <service
+            android:name=".starter.SelfStarterService"
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
@@ -25,6 +25,7 @@ public class ShizukuSettings {
     public static final String NIGHT_MODE = "night_mode";
     public static final String LANGUAGE = "language";
     public static final String KEEP_START_ON_BOOT = "start_on_boot";
+    public static final String KEEP_START_ON_BOOT_WIRELESS = "start_on_boot_wireless";
 
     private static SharedPreferences sPreferences;
 
@@ -35,11 +36,7 @@ public class ShizukuSettings {
     @NonNull
     private static Context getSettingsStorageContext(@NonNull Context context) {
         Context storageContext;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            storageContext = context.createDeviceProtectedStorageContext();
-        } else {
-            storageContext = context;
-        }
+        storageContext = context.createDeviceProtectedStorageContext();
 
         storageContext = new ContextWrapper(storageContext) {
             @Override
@@ -58,16 +55,11 @@ public class ShizukuSettings {
 
     public static void initialize(Context context) {
         if (sPreferences == null) {
-            sPreferences = getSettingsStorageContext(context)
-                    .getSharedPreferences(NAME, Context.MODE_PRIVATE);
+            sPreferences = getSettingsStorageContext(context).getSharedPreferences(NAME, Context.MODE_PRIVATE);
         }
     }
 
-    @IntDef({
-            LaunchMethod.UNKNOWN,
-            LaunchMethod.ROOT,
-            LaunchMethod.ADB,
-    })
+    @IntDef({LaunchMethod.UNKNOWN, LaunchMethod.ROOT, LaunchMethod.ADB,})
     @Retention(SOURCE)
     public @interface LaunchMethod {
         int UNKNOWN = -1;

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbWirelessHelper.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbWirelessHelper.kt
@@ -14,11 +14,13 @@ import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.BuildConfig
 import moe.shizuku.manager.ShizukuSettings
-import moe.shizuku.manager.ktx.TAG
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.starter.StarterActivity
 
 class AdbWirelessHelper {
+
+    private val adbWifiKey: String = "adb_wifi_enabled"
+
     fun validateThenEnableWirelessAdb(contentResolver: ContentResolver, context: Context): Boolean {
         val connectivityManager =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -36,7 +38,7 @@ class AdbWirelessHelper {
     private fun enableWirelessADB(contentResolver: ContentResolver, context: Context) {
         // Enable wireless ADB
         try {
-            Settings.Global.putInt(contentResolver, "adb_wifi_enabled", 1)
+            Settings.Global.putInt(contentResolver, adbWifiKey, 1)
             Log.i(AppConstants.TAG, "Wireless Debugging enabled via secure setting.")
             Toast.makeText(context, "Wireless Debugging enabled", Toast.LENGTH_SHORT).show()
         } catch (se: SecurityException) {

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbWirelessHelper.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbWirelessHelper.kt
@@ -1,0 +1,154 @@
+package moe.shizuku.manager.adb
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.AppConstants
+import moe.shizuku.manager.BuildConfig
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.ktx.TAG
+import moe.shizuku.manager.starter.Starter
+import moe.shizuku.manager.starter.StarterActivity
+
+class AdbWirelessHelper {
+    fun validateThenEnableWirelessAdb(contentResolver: ContentResolver, context: Context): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkCapabilities =
+            connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+        if (networkCapabilities != null && networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            enableWirelessADB(contentResolver, context)
+            return true
+        } else {
+            Log.w(AppConstants.TAG, "Wireless ADB auto-start condition not met: Not on Wi-Fi.")
+        }
+        return false
+    }
+
+    private fun enableWirelessADB(contentResolver: ContentResolver, context: Context) {
+        // Enable wireless ADB
+        try {
+            Settings.Global.putInt(contentResolver, "adb_wifi_enabled", 1)
+            Log.i(AppConstants.TAG, "Wireless Debugging enabled via secure setting.")
+            Toast.makeText(context, "Wireless Debugging enabled", Toast.LENGTH_SHORT).show()
+        } catch (se: SecurityException) {
+            Log.e(AppConstants.TAG, "Permission denied trying to enable wireless debugging.", se)
+            throw se
+        } catch (e: Exception) {
+            Log.e(AppConstants.TAG, "Error enabling wireless debugging.", e)
+            throw e
+        }
+    }
+
+    fun launchStarterActivity(context: Context, host: String, port: Int) {
+        val intent = Intent(context, StarterActivity::class.java).apply {
+            putExtra(StarterActivity.EXTRA_IS_ROOT, false)
+            putExtra(StarterActivity.EXTRA_HOST, host)
+            putExtra(StarterActivity.EXTRA_PORT, port)
+        }
+        context.startActivity(intent)
+    }
+
+    fun startShizukuViaAdb(
+        context: Context,
+        host: String,
+        port: Int,
+        coroutineScope: CoroutineScope,
+        onOutput: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onSuccess: () -> Unit = {}
+    ) {
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                Log.d(AppConstants.TAG, "Attempting to start Shizuku via ADB on $host:$port")
+                Starter.writeSdcardFiles(context)
+
+                val key = try {
+                    AdbKey(
+                        PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku"
+                    )
+                } catch (e: Throwable) {
+                    Log.e(AppConstants.TAG, "ADB Key error", e)
+                    onError(AdbKeyException(e))
+                    return@launch
+                }
+
+                val commandOutput = StringBuilder()
+
+                AdbClient(host, port, key).use { client ->
+                    try {
+                        client.connect()
+                        Log.i(
+                            AppConstants.TAG,
+                            "ADB connected to $host:$port. Executing starter command..."
+                        )
+
+                        client.shellCommand(Starter.sdcardCommand) { output ->
+                            val outputString = String(output)
+                            commandOutput.append(outputString)
+                            onOutput(outputString)
+                            Log.d(AppConstants.TAG, "Shizuku start output chunk: $outputString")
+                        }
+
+                        /* Adb on MIUI Android 11 has no permission to access Android/data.
+                          Before MIUI Android 12, we can temporarily use /data/user_de.
+                          After that, is better to implement "adb push" and push files directly to /data/local/tmp.
+                        */
+                        if (commandOutput.contains(
+                                "/Android/data/${BuildConfig.APPLICATION_ID}/start.sh: Permission denied"
+                            )
+                        ) {
+                            Log.w(
+                                AppConstants.TAG,
+                                "Detected permission issue, attempting fallback using /data/user_de"
+                            )
+
+                            val miuiMessage =
+                                "\n" + "adb have no permission to access Android/data, how could this possible ?!\n" + "try /data/user_de instead...\n" + "\n"
+                            onOutput(miuiMessage)
+
+                            Starter.writeDataFiles(context, true) // Write to data with permissions
+
+                            AdbClient(host, port, key).use { fallbackClient ->
+                                fallbackClient.connect()
+                                Log.i(
+                                    AppConstants.TAG,
+                                    "ADB reconnected for fallback. Executing data command..."
+                                )
+
+                                fallbackClient.shellCommand(Starter.dataCommand) { output ->
+                                    val outputString = String(output)
+                                    onOutput(outputString)
+                                    Log.d(
+                                        AppConstants.TAG,
+                                        "Shizuku fallback start output chunk: $outputString"
+                                    )
+                                }
+
+                                Log.i(AppConstants.TAG, "Shizuku fallback start command finished.")
+                            }
+                        }
+                    } catch (e: Throwable) {
+                        Log.e(AppConstants.TAG, "Error during ADB connection/command execution", e)
+                        onError(e)
+                        return@launch
+                    }
+                }
+
+                Log.i(AppConstants.TAG, "Shizuku start via ADB completed successfully")
+                onSuccess()
+            } catch (e: Throwable) {
+                Log.e(AppConstants.TAG, "Error in startShizukuViaAdb", e)
+                onError(e)
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -6,7 +6,6 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.os.SystemProperties
 import android.provider.Settings
 import android.view.LayoutInflater
 import androidx.annotation.RequiresApi
@@ -19,9 +18,7 @@ import moe.shizuku.manager.R
 import moe.shizuku.manager.adb.AdbMdns
 import moe.shizuku.manager.adb.AdbWirelessHelper
 import moe.shizuku.manager.databinding.AdbDialogBinding
-import moe.shizuku.manager.starter.StarterActivity
 import moe.shizuku.manager.utils.EnvironmentUtils
-import java.net.InetAddress
 
 @RequiresApi(Build.VERSION_CODES.R)
 class AdbDialogFragment : DialogFragment() {

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -17,8 +17,10 @@ import androidx.lifecycle.MutableLiveData
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import moe.shizuku.manager.R
 import moe.shizuku.manager.adb.AdbMdns
+import moe.shizuku.manager.adb.AdbWirelessHelper
 import moe.shizuku.manager.databinding.AdbDialogBinding
 import moe.shizuku.manager.starter.StarterActivity
+import moe.shizuku.manager.utils.EnvironmentUtils
 import java.net.InetAddress
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -27,14 +29,14 @@ class AdbDialogFragment : DialogFragment() {
     private lateinit var binding: AdbDialogBinding
     private lateinit var adbMdns: AdbMdns
     private val port = MutableLiveData<Int>()
+    private val adbWirelessHelper = AdbWirelessHelper()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
         binding = AdbDialogBinding.inflate(LayoutInflater.from(context))
         adbMdns = AdbMdns(context, AdbMdns.TLS_CONNECT, port)
 
-        var port = SystemProperties.getInt("service.adb.tcp.port", -1)
-        if (port == -1) port = SystemProperties.getInt("persist.adb.tcp.port", -1)
+        val port = EnvironmentUtils.getAdbTcpPort()
 
         val builder = MaterialAlertDialogBuilder(context).apply {
             setTitle(R.string.dialog_adb_discovery)
@@ -70,8 +72,7 @@ class AdbDialogFragment : DialogFragment() {
         }
 
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setOnClickListener {
-            var port = SystemProperties.getInt("service.adb.tcp.port", -1)
-            if (port == -1) port = SystemProperties.getInt("persist.adb.tcp.port", -1)
+            val port = EnvironmentUtils.getAdbTcpPort()
             startAndDismiss(port)
         }
 
@@ -83,13 +84,7 @@ class AdbDialogFragment : DialogFragment() {
 
     private fun startAndDismiss(port: Int) {
         val host = "127.0.0.1"
-        val intent = Intent(context, StarterActivity::class.java).apply {
-            putExtra(StarterActivity.EXTRA_IS_ROOT, false)
-            putExtra(StarterActivity.EXTRA_HOST, host)
-            putExtra(StarterActivity.EXTRA_PORT, port)
-        }
-        requireContext().startActivity(intent)
-
+        adbWirelessHelper.launchStarterActivity(requireContext(), host, port)
         dismissAllowingStateLoss()
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.FragmentActivity
 import moe.shizuku.manager.Helps
 import moe.shizuku.manager.R
 import moe.shizuku.manager.adb.AdbPairingTutorialActivity
+import moe.shizuku.manager.adb.AdbWirelessHelper
 import moe.shizuku.manager.databinding.HomeItemContainerBinding
 import moe.shizuku.manager.databinding.HomeStartWirelessAdbBinding
 import moe.shizuku.manager.ktx.toHtml
@@ -28,6 +29,8 @@ import java.net.Inet4Address
 
 class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: View) :
     BaseViewHolder<Any?>(root) {
+
+    private val adbWirelessHelper = AdbWirelessHelper()
 
     companion object {
         val CREATOR = Creator<Any> { inflater: LayoutInflater, parent: ViewGroup? ->
@@ -73,12 +76,7 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
         val port = EnvironmentUtils.getAdbTcpPort()
         if (port > 0) {
             val host = "127.0.0.1"
-            val intent = Intent(context, StarterActivity::class.java).apply {
-                putExtra(StarterActivity.EXTRA_IS_ROOT, false)
-                putExtra(StarterActivity.EXTRA_HOST, host)
-                putExtra(StarterActivity.EXTRA_PORT, port)
-            }
-            context.startActivity(intent)
+            adbWirelessHelper.launchStarterActivity(context, host, port)
         } else {
             WadbNotEnabledDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
         }
@@ -86,7 +84,7 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
 
     @RequiresApi(Build.VERSION_CODES.R)
     private fun onPairClicked(context: Context) {
-        if ((context.display?.displayId ?: -1) > 0) {
+        if (context.display.displayId > 0) {
             // Running in a multi-display environment (e.g., Windows Subsystem for Android),
             // pairing dialog can be displayed simultaneously with Shizuku.
             // Input from notification is harder to use under this situation.

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -1,22 +1,30 @@
 package moe.shizuku.manager.receiver
 
+import android.Manifest
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Process
 import android.util.Log
+import android.widget.Toast
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.ShizukuSettings.KEEP_START_ON_BOOT_WIRELESS
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
+import moe.shizuku.manager.ShizukuSettings.getPreferences
 import moe.shizuku.manager.starter.Starter
+import androidx.core.content.ContextCompat
+import moe.shizuku.manager.adb.AdbWirelessHelper
+import moe.shizuku.manager.starter.SelfStarterService
 import rikka.shizuku.Shizuku
 
 class BootCompleteReceiver : BroadcastReceiver() {
+    private val adbWirelessHelper = AdbWirelessHelper()
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (Intent.ACTION_LOCKED_BOOT_COMPLETED != intent.action
-            && Intent.ACTION_BOOT_COMPLETED != intent.action) {
+        if (Intent.ACTION_LOCKED_BOOT_COMPLETED != intent.action && Intent.ACTION_BOOT_COMPLETED != intent.action) {
             return
         }
 
@@ -30,13 +38,47 @@ class BootCompleteReceiver : BroadcastReceiver() {
                 return
             }
             start(context)
-        }
+        } else if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ADB) {
+            Log.i(AppConstants.TAG, "start on boot, action=" + intent.action)
+            if (Shizuku.pingBinder()) {
+                Log.i(AppConstants.TAG, "service is running")
+                return
+            }
+            if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+                val startOnBootWirelessAdbIsEnabled =
+                    getPreferences().getBoolean(KEEP_START_ON_BOOT_WIRELESS, false)
+                start(context, startOnBootWirelessAdbIsEnabled)
+            }
+        } else return
     }
 
-    private fun start(context: Context) {
+    private fun start(context: Context, startOnBootWirelessIsEnabled: Boolean = false) {
         if (!Shell.rootAccess()) {
+            if (startOnBootWirelessIsEnabled && ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.WRITE_SECURE_SETTINGS
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                Log.i(
+                    AppConstants.TAG,
+                    "WRITE_SECURE_SETTINGS is enabled and user has Start on boot is enabled for wireless ADB"
+                )
+
+                try {
+                    val wirelessAdbStatus = adbWirelessHelper.validateThenEnableWirelessAdb(
+                        context.contentResolver, context
+                    )
+                    if (wirelessAdbStatus) {
+                        Starter.writeSdcardFiles(context)
+                        val intentService = Intent(context, SelfStarterService::class.java)
+                        context.startService(intentService)
+                    }
+                } catch (e: SecurityException) {
+                    e.printStackTrace()
+                    Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+                }
+            } else
             //NotificationHelper.notify(context, AppConstants.NOTIFICATION_ID_STATUS, AppConstants.NOTIFICATION_CHANNEL_STATUS, R.string.notification_service_start_no_root)
-            return
+                return
         }
 
         Starter.writeDataFiles(context)

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiver.kt
@@ -3,13 +3,31 @@ package moe.shizuku.manager.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.model.ServiceStatus
 import moe.shizuku.manager.shell.ShellBinderRequestHandler
+import moe.shizuku.manager.adb.AdbWirelessHelper
+import moe.shizuku.manager.starter.SelfStarterService
 
 class ShizukuReceiver : BroadcastReceiver() {
+    private val adbWirelessHelper = AdbWirelessHelper()
 
     override fun onReceive(context: Context, intent: Intent) {
         if ("rikka.shizuku.intent.action.REQUEST_BINDER" == intent.action) {
             ShellBinderRequestHandler.handleRequest(context, intent)
+        }
+        if (!ServiceStatus().isRunning) {
+            val startOnBootWirelessIsEnabled = ShizukuSettings.getPreferences()
+                .getBoolean(ShizukuSettings.KEEP_START_ON_BOOT_WIRELESS, false)
+            if (startOnBootWirelessIsEnabled) {
+                val wirelessAdbStatus = adbWirelessHelper.validateThenEnableWirelessAdb(
+                    context.contentResolver, context
+                )
+                if (wirelessAdbStatus) {
+                    val intentService = Intent(context, SelfStarterService::class.java)
+                    context.startService(intentService)
+                }
+            }
         }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
@@ -1,7 +1,9 @@
 package moe.shizuku.manager.settings
 
+import android.Manifest
 import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
@@ -10,11 +12,15 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.ContextCompat
 import androidx.preference.*
+import android.util.Log
+import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.KEEP_START_ON_BOOT
+import moe.shizuku.manager.ShizukuSettings.KEEP_START_ON_BOOT_WIRELESS
 import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
@@ -32,6 +38,8 @@ import rikka.widget.borderview.BorderRecyclerView
 import java.util.*
 import moe.shizuku.manager.ShizukuSettings.LANGUAGE as KEY_LANGUAGE
 import moe.shizuku.manager.ShizukuSettings.NIGHT_MODE as KEY_NIGHT_MODE
+import androidx.core.content.edit
+import moe.shizuku.manager.ktx.TAG
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
@@ -39,6 +47,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private lateinit var nightModePreference: IntegerSimpleMenuPreference
     private lateinit var blackNightThemePreference: TwoStatePreference
     private lateinit var startOnBootPreference: TwoStatePreference
+    private lateinit var startOnBootWirelessPreference: TwoStatePreference
     private lateinit var startupPreference: PreferenceCategory
     private lateinit var translationPreference: Preference
     private lateinit var translationContributorsPreference: Preference
@@ -56,21 +65,62 @@ class SettingsFragment : PreferenceFragmentCompat() {
         nightModePreference = findPreference(KEY_NIGHT_MODE)!!
         blackNightThemePreference = findPreference(KEY_BLACK_NIGHT_THEME)!!
         startOnBootPreference = findPreference(KEEP_START_ON_BOOT)!!
+        startOnBootWirelessPreference = findPreference(KEEP_START_ON_BOOT_WIRELESS)!!
         startupPreference = findPreference("startup")!!
         translationPreference = findPreference("translation")!!
         translationContributorsPreference = findPreference("translation_contributors")!!
         useSystemColorPreference = findPreference(KEY_USE_SYSTEM_COLOR)!!
 
-        val componentName = ComponentName(context.packageName, BootCompleteReceiver::class.java.name)
+        val componentName =
+            ComponentName(context.packageName, BootCompleteReceiver::class.java.name)
+        // Initialize toggles based on saved preferences
+        updatePreferenceStates(componentName)
 
-        startOnBootPreference.isChecked = context.packageManager.isComponentEnabled(componentName)
         startOnBootPreference.onPreferenceChangeListener =
-            Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+            Preference.OnPreferenceChangeListener { _, newValue ->
                 if (newValue is Boolean) {
-                    context.packageManager.setComponentEnabled(componentName, newValue)
-                    context.packageManager.isComponentEnabled(componentName) == newValue
+                    if (newValue) {
+                        // These two options are mutually exclusive. So, disable the wireless option
+                        startOnBootWirelessPreference.isChecked = false
+                        savePreference(KEEP_START_ON_BOOT_WIRELESS, false)
+                    }
+                    toggleBootComponent(
+                        componentName,
+                        KEEP_START_ON_BOOT,
+                        newValue || startOnBootPreference.isChecked
+                    )
                 } else false
             }
+
+        startOnBootWirelessPreference.onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { _, newValue ->
+                val hasSecurePermission = ContextCompat.checkSelfPermission(
+                    requireContext(), Manifest.permission.WRITE_SECURE_SETTINGS
+                ) == PackageManager.PERMISSION_GRANTED
+                if (newValue is Boolean) {
+                    if (newValue) {
+                        // Check for permission
+                        if (!hasSecurePermission) {
+                            Toast.makeText(
+                                context,
+                                R.string.permission_write_secure_settings_required,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            return@OnPreferenceChangeListener false
+                        }
+
+                        // Disable the root option because, mutual exclusivity
+                        startOnBootPreference.isChecked = false
+                        savePreference(KEEP_START_ON_BOOT, false)
+                    }
+                    toggleBootComponent(
+                        componentName,
+                        KEEP_START_ON_BOOT_WIRELESS,
+                        newValue || startOnBootPreference.isChecked
+                    )
+                } else false
+            }
+
         languagePreference.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
                 if (newValue is String) {
@@ -125,8 +175,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
             useSystemColorPreference.isVisible = false
         }
 
-        translationPreference.summary =
-            context.getString(R.string.settings_translation_summary, context.getString(R.string.app_name))
+        translationPreference.summary = context.getString(
+            R.string.settings_translation_summary, context.getString(R.string.app_name)
+        )
         translationPreference.setOnPreferenceClickListener {
             CustomTabsHelper.launchUrlOrCopy(context, context.getString(R.string.translation_url))
             true
@@ -141,17 +192,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     override fun onCreateRecyclerView(
-        inflater: LayoutInflater,
-        parent: ViewGroup,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, parent: ViewGroup, savedInstanceState: Bundle?
     ): RecyclerView {
-        val recyclerView = super.onCreateRecyclerView(inflater, parent, savedInstanceState) as BorderRecyclerView
+        val recyclerView =
+            super.onCreateRecyclerView(inflater, parent, savedInstanceState) as BorderRecyclerView
         recyclerView.fixEdgeEffect()
         recyclerView.addEdgeSpacing(bottom = 8f, unit = TypedValue.COMPLEX_UNIT_DIP)
 
         val lp = recyclerView.layoutParams
         if (lp is FrameLayout.LayoutParams) {
-            lp.rightMargin = recyclerView.context.resources.getDimension(R.dimen.rd_activity_horizontal_margin).toInt()
+            lp.rightMargin =
+                recyclerView.context.resources.getDimension(R.dimen.rd_activity_horizontal_margin)
+                    .toInt()
             lp.leftMargin = lp.rightMargin
         }
 
@@ -177,15 +229,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
             }
 
             val locale = Locale.forLanguageTag(displayLocale.toString())
-            val localeName = if (!TextUtils.isEmpty(locale.script))
-                locale.getDisplayScript(locale)
-            else
-                locale.getDisplayName(locale)
+            val localeName = if (!TextUtils.isEmpty(locale.script)) locale.getDisplayScript(locale)
+            else locale.getDisplayName(locale)
 
-            val localizedLocaleName = if (!TextUtils.isEmpty(locale.script))
-                locale.getDisplayScript(currentLocale)
-            else
-                locale.getDisplayName(currentLocale)
+            val localizedLocaleName =
+                if (!TextUtils.isEmpty(locale.script)) locale.getDisplayScript(currentLocale)
+                else locale.getDisplayName(currentLocale)
 
             localizedLocales.add(
                 if (index != currentLocaleIndex) {
@@ -202,6 +251,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             TextUtils.isEmpty(currentLocaleTag) || "SYSTEM" == currentLocaleTag -> {
                 getString(R.string.follow_system)
             }
+
             currentLocaleIndex != -1 -> {
                 val localizedLocale = localizedLocales[currentLocaleIndex]
                 val newLineIndex = localizedLocale.indexOf('\n')
@@ -211,9 +261,49 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     localizedLocale.subSequence(0, newLineIndex).toString()
                 }
             }
+
             else -> {
                 ""
             }
         }
+    }
+
+    private fun savePreference(key: String, value: Boolean) {
+        ShizukuSettings.getPreferences().edit() { putBoolean(key, value) }
+    }
+
+    private fun updatePreferenceStates(componentName: ComponentName) {
+        val isComponentEnabled = context?.packageManager?.isComponentEnabled(componentName) == true
+        val isWirelessBootEnabled =
+            ShizukuSettings.getPreferences().getBoolean(KEEP_START_ON_BOOT_WIRELESS, false)
+        val hasSecurePermission = ContextCompat.checkSelfPermission(
+            requireContext(), Manifest.permission.WRITE_SECURE_SETTINGS
+        ) == PackageManager.PERMISSION_GRANTED
+
+        startOnBootPreference.isChecked = isComponentEnabled && !isWirelessBootEnabled
+        startOnBootWirelessPreference.isChecked =
+            isComponentEnabled && isWirelessBootEnabled && hasSecurePermission
+    }
+
+    private fun toggleBootComponent(
+        componentName: ComponentName, key: String, enabled: Boolean
+    ): Boolean {
+        savePreference(key, enabled)
+
+        try {
+            context?.packageManager?.setComponentEnabled(componentName, enabled)
+
+            val isEnabled = context?.packageManager?.isComponentEnabled(componentName) == enabled
+            if (!isEnabled) {
+                Log.e(TAG, "Failed to set component state: $componentName to $enabled")
+                return false
+            }
+
+        } catch (e: Exception) {
+            Log.e(TAG, getString(R.string.wireless_boot_component_error), e)
+            return false
+        }
+
+        return true
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/starter/SelfStarterService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/SelfStarterService.kt
@@ -1,0 +1,158 @@
+package moe.shizuku.manager.starter
+
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import androidx.lifecycle.*
+import java.net.ConnectException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.AppConstants
+import moe.shizuku.manager.adb.*
+import moe.shizuku.manager.utils.EnvironmentUtils
+import rikka.shizuku.Shizuku
+
+class SelfStarterService : Service(), LifecycleOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle
+        get() = lifecycleRegistry
+
+    private val portLive = MutableLiveData<Int>()
+    private var adbMdns: AdbMdns? = null
+    private val adbWirelessHelper = AdbWirelessHelper()
+
+    private val portObserver =
+        Observer<Int> { p ->
+            if (p in 1..65535) {
+                Log.i(
+                    AppConstants.TAG,
+                    "Discovered adb port via mDNS: $p, starting Shizuku directly"
+                )
+                // Do not launch activity, start ADB connection directly
+                startShizukuViaAdb("127.0.0.1", p)
+            } else {
+                Log.w(AppConstants.TAG, "mDNS returned invalid port: $p")
+            }
+        }
+
+    override fun onCreate() {
+        super.onCreate()
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        Log.i(AppConstants.TAG, "SelfStarterService created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        Log.i(AppConstants.TAG, "SelfStarterService starting command")
+
+        // Already running? Bail out.
+        if (Shizuku.pingBinder()) {
+            Log.i(AppConstants.TAG, "Shizuku is already running, stopping service.")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        val wirelessEnabled = Settings.Global.getInt(contentResolver, "adb_wifi_enabled", 0) == 1
+        Log.d(AppConstants.TAG, "Wireless Debugging enabled setting: $wirelessEnabled")
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && wirelessEnabled) {
+            Log.i(AppConstants.TAG, "Starting mDNS discovery for wireless ADB port.")
+
+            // Remove potential previous observer before adding a new one
+            portLive.removeObserver(portObserver)
+            portLive.observeForever(portObserver)
+
+            if (adbMdns == null) {
+                adbMdns =
+                    AdbMdns(context = this, serviceType = AdbMdns.TLS_CONNECT, port = portLive)
+            }
+            adbMdns?.start()
+        } else {
+            Log.i(
+                AppConstants.TAG,
+                "Using fallback: SystemProperties for ADB port (or wireless debugging setting off)."
+            )
+            val port = EnvironmentUtils.getAdbTcpPort()
+            if (port > 0) {
+                Log.i(
+                    AppConstants.TAG,
+                    "Found adb port via SystemProperties: $port, starting Shizuku directly."
+                )
+                startShizukuViaAdb("127.0.0.1", port)
+            } else {
+                Log.e(
+                    AppConstants.TAG,
+                    "Could not determine ADB TCP port via SystemProperties, aborting."
+                )
+                stopSelf()
+            }
+        }
+
+        // Service should only run once per trigger
+        return START_NOT_STICKY
+    }
+
+    private fun startShizukuViaAdb(host: String, port: Int) {
+        lifecycleScope.launch(Dispatchers.Main) {
+            Toast.makeText(this@SelfStarterService, "Starting Shizuku service…", Toast.LENGTH_SHORT)
+                .show()
+        }
+
+        adbWirelessHelper.startShizukuViaAdb(
+            context = applicationContext,
+            host = host,
+            port = port,
+            coroutineScope = lifecycleScope,
+            onOutput = { /* No UI to update in service */ },
+            onError = { e ->
+                lifecycleScope.launch(Dispatchers.Main) {
+                    when (e) {
+                        is AdbKeyException ->
+                            Toast.makeText(
+                                applicationContext,
+                                "ADB Key error during Shizuku start",
+                                Toast.LENGTH_LONG
+                            )
+                                .show()
+
+                        is ConnectException ->
+                            Toast.makeText(
+                                applicationContext,
+                                "ADB Connection failed to $host:$port",
+                                Toast.LENGTH_LONG
+                            )
+                                .show()
+
+                        else ->
+                            Toast.makeText(
+                                applicationContext,
+                                "Error: ${e.message}",
+                                Toast.LENGTH_LONG
+                            )
+                                .show()
+                    }
+                    stopSelf()
+                }
+            },
+            onSuccess = { lifecycleScope.launch(Dispatchers.Main) { stopSelf() } }
+        )
+    }
+
+    override fun onDestroy() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Log.i(AppConstants.TAG, "SelfStarterService destroying")
+            adbMdns?.stop()
+        }
+
+        portLive.removeObserver(portObserver) // Clean up the observer
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
@@ -10,7 +10,15 @@ import moe.shizuku.manager.ktx.createDeviceProtectedStorageContextCompat
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.ktx.loge
 import rikka.core.os.FileUtils
-import java.io.*
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.DataInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FileWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.PrintWriter
 import java.util.zip.ZipFile
 
 object Starter {

--- a/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
@@ -31,12 +31,13 @@ object Starter {
         }
 
         val um = context.getSystemService(UserManager::class.java)!!
-        val unlocked = Build.VERSION.SDK_INT < 24 || um.isUserUnlocked
+        val unlocked = false || um.isUserUnlocked
         if (!unlocked) {
             throw IllegalStateException("User is locked")
         }
 
-        val filesDir = context.getExternalFilesDir(null) ?: throw IOException("getExternalFilesDir() returns null")
+        val filesDir = context.getExternalFilesDir(null)
+            ?: throw IOException("getExternalFilesDir() returns null")
         val dir = filesDir.parentFile ?: throw IOException("$filesDir parentFile returns null")
         val starter = copyStarter(context, File(dir, "starter"))
         val sh = writeScript(context, File(dir, "start.sh"), starter)

--- a/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/Starter.kt
@@ -31,7 +31,7 @@ object Starter {
         }
 
         val um = context.getSystemService(UserManager::class.java)!!
-        val unlocked = false || um.isUserUnlocked
+        val unlocked = um.isUserUnlocked
         if (!unlocked) {
             throw IllegalStateException("User is locked")
         }

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
@@ -132,12 +133,11 @@ private class ViewModel(context: Context, root: Boolean, host: String?, port: In
         else _output.postValue(Resource.error(throwable, sb))
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun startRoot() {
         sb.append("Starting with root...").append('\n').append('\n')
         postResult()
 
-        GlobalScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
             if (!Shell.rootAccess()) {
                 Shell.getCachedShell()?.close()
                 sb.append('\n').append("Can't open root shell, try again...").append('\n')
@@ -165,7 +165,6 @@ private class ViewModel(context: Context, root: Boolean, host: String?, port: In
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun startAdb(context: Context, host: String, port: Int) {
         sb.append("Starting with wireless adb...").append('\n').append('\n')
         postResult()
@@ -174,7 +173,7 @@ private class ViewModel(context: Context, root: Boolean, host: String?, port: In
             context = context,
             host = host,
             port = port,
-            coroutineScope = GlobalScope,
+            coroutineScope = viewModelScope,
             onOutput = { outputString ->
                 sb.append(outputString)
                 postResult()

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -2,23 +2,21 @@ package moe.shizuku.manager.starter
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
+import java.net.ConnectException
+import javax.net.ssl.SSLProtocolException
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants.EXTRA
-import moe.shizuku.manager.BuildConfig
 import moe.shizuku.manager.R
-import moe.shizuku.manager.ShizukuSettings
-import moe.shizuku.manager.adb.AdbClient
-import moe.shizuku.manager.adb.AdbKey
 import moe.shizuku.manager.adb.AdbKeyException
-import moe.shizuku.manager.adb.PreferenceAdbKeyStore
+import moe.shizuku.manager.adb.AdbWirelessHelper
 import moe.shizuku.manager.app.AppBarActivity
 import moe.shizuku.manager.application
 import moe.shizuku.manager.databinding.StarterActivityBinding
@@ -26,8 +24,6 @@ import rikka.lifecycle.Resource
 import rikka.lifecycle.Status
 import rikka.lifecycle.viewModels
 import rikka.shizuku.Shizuku
-import java.net.ConnectException
-import javax.net.ssl.SSLProtocolException
 
 private class NotRootedException : Exception()
 
@@ -60,11 +56,11 @@ class StarterActivity : AppBarActivity() {
                 Shizuku.addBinderReceivedListenerSticky(object : Shizuku.OnBinderReceivedListener {
                     override fun onBinderReceived() {
                         Shizuku.removeBinderReceivedListener(this)
-                        viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
+                        viewModel.appendOutput(
+                            "Service started, this window will be automatically closed in 3 seconds"
+                        )
 
-                        window?.decorView?.postDelayed({
-                            if (!isFinishing) finish()
-                        }, 3000)
+                        window?.decorView?.postDelayed({ if (!isFinishing) finish() }, 3000)
                     }
                 })
             } else if (it.status == Status.ERROR) {
@@ -73,22 +69,23 @@ class StarterActivity : AppBarActivity() {
                     is AdbKeyException -> {
                         message = R.string.adb_error_key_store
                     }
+
                     is NotRootedException -> {
                         message = R.string.start_with_root_failed
                     }
+
                     is ConnectException -> {
                         message = R.string.cannot_connect_port
                     }
+
                     is SSLProtocolException -> {
                         message = R.string.adb_pair_required
                     }
                 }
 
                 if (message != 0) {
-                    MaterialAlertDialogBuilder(this)
-                        .setMessage(message)
-                        .setPositiveButton(android.R.string.ok, null)
-                        .show()
+                    MaterialAlertDialogBuilder(this).setMessage(message)
+                        .setPositiveButton(android.R.string.ok, null).show()
                 }
             }
             binding.text1.text = output
@@ -103,20 +100,22 @@ class StarterActivity : AppBarActivity() {
     }
 }
 
-private class ViewModel(context: Context, root: Boolean, host: String?, port: Int) : androidx.lifecycle.ViewModel() {
+private class ViewModel(context: Context, root: Boolean, host: String?, port: Int) :
+    androidx.lifecycle.ViewModel() {
 
     private val sb = StringBuilder()
     private val _output = MutableLiveData<Resource<StringBuilder>>()
+    private val adbWirelessHelper = AdbWirelessHelper()
 
     val output = _output as LiveData<Resource<StringBuilder>>
 
     init {
         try {
             if (root) {
-                //Starter.writeFiles(context)
+                // Starter.writeFiles(context)
                 startRoot()
             } else {
-                startAdb(host!!, port)
+                startAdb(context, host!!, port)
             }
         } catch (e: Throwable) {
             postResult(e)
@@ -129,12 +128,11 @@ private class ViewModel(context: Context, root: Boolean, host: String?, port: In
     }
 
     private fun postResult(throwable: Throwable? = null) {
-        if (throwable == null)
-            _output.postValue(Resource.success(sb))
-        else
-            _output.postValue(Resource.error(throwable, sb))
+        if (throwable == null) _output.postValue(Resource.success(sb))
+        else _output.postValue(Resource.error(throwable, sb))
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     private fun startRoot() {
         sb.append("Starting with root...").append('\n').append('\n')
         postResult()
@@ -167,62 +165,20 @@ private class ViewModel(context: Context, root: Boolean, host: String?, port: In
         }
     }
 
-    private fun startAdb(host: String, port: Int) {
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun startAdb(context: Context, host: String, port: Int) {
         sb.append("Starting with wireless adb...").append('\n').append('\n')
         postResult()
 
-        GlobalScope.launch(Dispatchers.IO) {
-            val key = try {
-                AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-            } catch (e: Throwable) {
-                e.printStackTrace()
-                sb.append('\n').append(Log.getStackTraceString(e))
-
-                postResult(AdbKeyException(e))
-                return@launch
-            }
-
-            AdbClient(host, port, key).runCatching {
-                connect()
-                shellCommand(Starter.sdcardCommand) {
-                    sb.append(String(it))
-                    postResult()
-                }
-                close()
-            }.onFailure {
-                it.printStackTrace()
-
-                sb.append('\n').append(Log.getStackTraceString(it))
-                postResult(it)
-            }
-
-            /* Adb on MIUI Android 11 has no permission to access Android/data.
-               Before MIUI Android 12, we can temporarily use /data/user_de.
-               After that, is better to implement "adb push" and push files directly to /data/local/tmp.
-             */
-            if (sb.contains("/Android/data/${BuildConfig.APPLICATION_ID}/start.sh: Permission denied")) {
-                sb.append('\n')
-                    .appendLine("adb have no permission to access Android/data, how could this possible ?!")
-                    .appendLine("try /data/user_de instead...")
-                    .appendLine()
+        adbWirelessHelper.startShizukuViaAdb(
+            context = context,
+            host = host,
+            port = port,
+            coroutineScope = GlobalScope,
+            onOutput = { outputString ->
+                sb.append(outputString)
                 postResult()
-
-                Starter.writeDataFiles(application, true)
-
-                AdbClient(host, port, key).runCatching {
-                    connect()
-                    shellCommand(Starter.dataCommand) {
-                        sb.append(String(it))
-                        postResult()
-                    }
-                    close()
-                }.onFailure {
-                    it.printStackTrace()
-
-                    sb.append('\n').append(Log.getStackTraceString(it))
-                    postResult(it)
-                }
-            }
-        }
+            },
+            onError = { e -> postResult(e) })
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -8,11 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
-import java.net.ConnectException
-import javax.net.ssl.SSLProtocolException
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants.EXTRA
 import moe.shizuku.manager.R
@@ -25,6 +21,8 @@ import rikka.lifecycle.Resource
 import rikka.lifecycle.Status
 import rikka.lifecycle.viewModels
 import rikka.shizuku.Shizuku
+import java.net.ConnectException
+import javax.net.ssl.SSLProtocolException
 
 private class NotRootedException : Exception()
 

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
 
     <!-- Home - Wireless Adb -->
     <string name="home_wireless_adb_title"><![CDATA[Start via Wireless debugging]]></string>
-    <string name="home_wireless_adb_description"><![CDATA[On Android 11 or above, you can enable Wireless debugging and start Shizuku directly from your device, without connecting to a computer.<p>Please view the step-by-step guide first.]]></string>
+    <string name="home_wireless_adb_description"><![CDATA[On Android 11 or above, you can enable Wireless debugging and start Shizuku directly from your device, without connecting to a computer.<p>In addition, Shizuku can be started automatically on boot without root if WRITE_SECURE_SETTINGS permission is granted.<p>Please view the step-by-step guide first.]]></string>
     <string name="home_wireless_adb_description_pre_11"><![CDATA[Before Android 11, connecting to a computer is required to enable Wireless debugging.]]></string>
     <string name="home_wireless_adb_view_guide_button">Step-by-step guide</string>
 
@@ -107,13 +107,21 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_user_interface">Appearance</string>
     <string name="settings_black_night_theme">Black night theme</string>
     <string name="settings_black_night_theme_summary">Use the pure black theme if night mode is enabled</string>
-    <string name="settings_startup">Startup</string>
+    <string name="settings_startup">Startup (only one of them can be enabled at a time)</string>
     <string name="settings_translation_contributors">Translation contributors</string>
     <string name="settings_translation">Participate in translation</string>
     <string name="settings_translation_summary">Help us translate %s into your language</string>
     <string name="settings_start_on_boot">Start on boot (root)</string>
+    <string name="settings_start_on_boot_wireless">Start on boot (wireless ADB)</string>
     <string name="settings_start_on_boot_summary">For rooted devices, Shizuku is able to start automatically on boot</string>
+    <string name="settings_start_on_boot_wireless_summary">For rootless devices, Shizuku is able to start automatically on boot with Wireless ADB</string>
     <string name="settings_use_system_color">Use system theme color</string>
+
+    <!-- Wireless Boot -->
+    <string name="wireless_boot_enabled">Wireless ADB auto-start enabled</string>
+    <string name="wireless_boot_component_error">Failed to enable boot component</string>
+    <string name="wireless_boot_permission_tooltip">To automatically start Shizuku on boot with wireless ADB, the WRITE_SECURE_SETTINGS permission must be granted</string>
+    <string name="wireless_boot_wifi_required">This feature requires Wi-Fi connection to work</string>
 
     <!-- About -->
     <string name="action_about">About</string>
@@ -148,10 +156,16 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="permission_warning_template"><![CDATA[Allow <b>%1$s</b> to %2$s?]]></string>
     <string name="grant_dialog_button_allow_always">Allow all the time</string>
     <string name="grant_dialog_button_deny">"Deny"</string>
-
+    
+    <string name="permission_write_secure_settings_required">WRITE_SECURE_SETTINGS permission is required for this feature</string>
+    <string name="permission_write_secure_settings_grant_info">This permission can be granted via ADB using the command:\nadb shell pm grant moe.shizuku.manager android.permission.WRITE_SECURE_SETTINGS</string>
+    <string name="permission_missing">Permission required</string>
+    <string name="permission_disabled_feature">Feature disabled due to missing permission</string>
+    
     <!-- Starter -->
     <string name="starter">Starter</string>
     <string name="starting_root_shell" translatable="false">Starting root shell…</string>
+    <string name="starting_on_wireless_adb" translatable="false">Starting service with wirelessADB…</string>
     <string name="start_with_root_failed">Can\'t start service because root permission is not granted or this device is not rooted.</string>
 
     <!-- Misc -->

--- a/manager/src/main/res/xml/settings.xml
+++ b/manager/src/main/res/xml/settings.xml
@@ -10,6 +10,11 @@
             android:summary="@string/settings_start_on_boot_summary"
             android:title="@string/settings_start_on_boot" />
 
+        <rikka.material.preference.MaterialSwitchPreference
+            android:key="start_on_boot_wireless"
+            android:summary="@string/settings_start_on_boot_wireless_summary"
+            android:title="@string/settings_start_on_boot_wireless" />
+        
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_language">


### PR DESCRIPTION
This PR (re)introduces auto start feature for rootless that makes use of `WRITE_SECURE_SETTINGS` permission on Android.

The [previous](https://github.com/pixincreate/Shizuku/commit/4466c11dbc2bcd7e968c3ca8e93bd7e02b500bfd) implementation had a lot of performance issues such as:

- Service failing to start occasionally after boot
- Code duplication between `StarterActivity` and `SelfStarterService`
- Slow start of service post boot

This new implementation addresses all of these. Below are the changes that are introduced in this PR:

- The app now requires a new permission `FOREGROUND_SERVICE_CONNECTED_DEVICE` for ADB pairing service since target SDK has been set to `35` which has more clear and stricter permission requirements in addition to WIFI related permissions that are required for Wireless ADB auto start service
- Moved the common code that are used by the `SelfStarterService` and `StarterActivity` to start Shizuku service with wireless ADB to `AdbWirelessHelper`
- A better logic and efficient implementation for faster detection and starting of service