### PR TITLE
feat: throw a pop-up asking user to enable `WRITE_SECURE_SETTINGS` permission

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
@@ -26,6 +26,7 @@ public class ShizukuSettings {
     public static final String KEEP_START_ON_BOOT = "start_on_boot";
     public static final String KEEP_START_ON_BOOT_WIRELESS = "start_on_boot_wireless";
     public static final String ADB_ROOT = "adb_root";
+    public static final String PENDING_SECURE_SETTINGS_GRANT = "pending_secure_settings_grant";
 
     private static SharedPreferences sPreferences;
 

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
@@ -465,7 +465,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
             try {
                 val success = kotlin.runCatching {
                     grantSecureSettingsWithShizuku()
-                    Thread.sleep(200)
                     hasSecureSettingsPermission()
                 }.onFailure { e ->
                     Log.e(TAG, "Error auto-granting permission", e)
@@ -514,6 +513,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 BuildConfig.APPLICATION_ID, Manifest.permission.WRITE_SECURE_SETTINGS, userId
             )
 
+            Thread.sleep(200)
+            
             Log.i(TAG, "Requested WRITE_SECURE_SETTINGS grant via Shizuku for user $userId")
         } catch (e: Exception) {
             Log.e(TAG, "Error granting permission via Shizuku", e)

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsFragment.kt
@@ -390,8 +390,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
         MaterialAlertDialogBuilder(context).setTitle(R.string.permission_required).setMessage(
                 HtmlCompat.fromHtml(
                     """
-                <h3>${getString(R.string.permission_write_secure_settings_required)}</h3>
-                <p>${getString(R.string.permission_write_secure_settings_grant_info)}</p>
+                <p>${getString(R.string.permission_write_secure_settings_required)}</p>
+                <h3>Warning</h3>
+                <p><tt>WRITE_SECURE_SETTINGS</tt> is a very sensitive permission and enable it only if you know what you're doing as the permission allows the application to read or write the secure system settings.</p>
                 """.trimIndent()
                 )
             ).setPositiveButton(R.string.permission_grant_automatically) { _, _ ->

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -159,10 +159,15 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="grant_dialog_button_allow_always">Allow all the time</string>
     <string name="grant_dialog_button_deny">"Deny"</string>
 
-    <string name="permission_write_secure_settings_required">WRITE_SECURE_SETTINGS permission is required for this feature</string>
+    <string name="start_shizuku_first">Please start Shizuku service first. Returning to the main screen.</string>
+    <string name="permission_write_secure_settings_required">The Start on Boot (Wireless ADB) feature requires the WRITE_SECURE_SETTINGS permission to be granted.</string>
     <string name="permission_write_secure_settings_grant_info">This permission can be granted via ADB using the command:\nadb shell pm grant moe.shizuku.manager android.permission.WRITE_SECURE_SETTINGS</string>
-    <string name="permission_missing">Permission required</string>
+    <string name="permission_required">Permission required</string>
     <string name="permission_disabled_feature">Feature disabled due to missing permission</string>
+    <string name="permission_grant_automatically">Automatic Setup</string>
+    <string name="permission_grant_manually">Manual Setup</string>
+    <string name="permission_granted">Permission granted successfully</string>
+    <string name="permission_grant_failed">Failed to grant permission</string>
 
     <!-- Starter -->
     <string name="starter">Starter</string>


### PR DESCRIPTION
Inspired from https://github.com/pixincreate/Shizuku/commit/6f3b26e6325eeb3868677afd9ddadeb5e6a0bb07


Initial thought that I had was to throw a pop-up in home screen after user starts the Shizuku service. Now that I think about it, this approach is more cleaner as the pop-up is restricted to the feature that is added:

<img width="211" alt="image" src="https://github.com/user-attachments/assets/73dd15b8-62b9-4118-8735-218307ffaedc" />

ref: https://developer.android.com/reference/android/Manifest.permission#WRITE_SECURE_SETTINGS
